### PR TITLE
Made a few improvements, hope you like them!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 *.swp
+bittornado.tar.gz

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ makes it really trivial to integrate into whatever deployment system you like.
 
 ## Requirements
 
-Herd needs Python > 2.5 and eventlet (on the source system only). All other libraries
+Herd needs Python > 2.5, argparse,  and eventlet (on the source system only). All other libraries
 are shipped with it. To install eventlet, you can just do:
 
     easy_install eventlet
@@ -26,6 +26,10 @@ are shipped with it. To install eventlet, you can just do:
 On CentOS:
 
     yum install python-eventlet
+
+Argparse can be found with easy_install as well:
+
+    easy_install argparse
 
 ## Usage
 

--- a/herd.py
+++ b/herd.py
@@ -4,17 +4,51 @@ import sys
 import os
 import time
 import eventlet
+import re
+import argparse
 from eventlet.green import socket
 from eventlet.green import subprocess
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('local-file',
+                    help='Local file to upload')
+
+parser.add_argument('remote-file',
+                    help="Remote file destination")
+
+parser.add_argument('hosts',
+                    help="File containing list of hosts")
+
+parser.add_argument('--retry',
+                    default=0,
+                    type=int,
+                    help="Number of times to retry in case of failure. " + 
+                    "Use -1 to make it retry forever (not recommended)")
+
+parser.add_argument('--port',
+                    default=8998,
+                    help="Port number to run the tracker on")
+
+parser.add_argument('--remote-path',
+                    default='/tmp/herd',
+                    help="Temporary path to store uploads")
+
+parser.add_argument('--data-file',
+                    default='./data',
+                    help="Temporary file to store for bittornado.")
+
+parser.add_argument('--log-dir',
+                    default='/tmp/herd',
+                    help="Path to the directory for murder logs")
+
+opts = vars(parser.parse_args())
 
 
 murder_client = eventlet.import_patched('murder_client')
 bttrack = eventlet.import_patched('BitTornado.BT1.track')
 makemetafile = eventlet.import_patched('BitTornado.BT1.makemetafile')
 
-PORT = 8998
-REMOTE_PATH = '/tmp/herd'
-DATA_FILE = './data'
 
 herd_root = os.path.dirname(__file__)
 bittornado_tgz = os.path.join(herd_root, 'bittornado.tar.gz')
@@ -25,7 +59,7 @@ def run(local_file, remote_file, hosts):
     print "Spawning tracker..."
     eventlet.spawn(track)
     eventlet.sleep(1)
-    local_host = (local_ip(), PORT)
+    local_host = (local_ip(), opts['port'])
     print "Creating torrent (host %s:%s)..." % local_host
     torrent_file = mktorrent(local_file, '%s:%s' % local_host)
     print "Seeding %s" % torrent_file
@@ -41,19 +75,19 @@ def run(local_file, remote_file, hosts):
     pool = eventlet.GreenPool(100)
     threads = []
     for host in hosts:
-        threads.append(pool.spawn(transfer, host, torrent_file, remote_file))
+        threads.append(pool.spawn(transfer, host, torrent_file, remote_file, opts['retry']))
     for thread in threads:
         thread.wait()
     os.unlink(torrent_file)
     try:
-        os.unlink(DATA_FILE)
+        os.unlink(opts['data_file'])
     except OSError:
         pass
     print "Finished, took %.2f seconds." % (time.time() - start)
 
 
-def transfer(host, local_file, remote_target):
-    rp = REMOTE_PATH
+def transfer(host, local_file, remote_target, retry=0):
+    rp = opts['remote_path']
     file_name = os.path.basename(local_file)
     remote_file = '%s/%s' % (rp, file_name)
     print "Copying %s to %s:%s" % (local_file, host, remote_file)
@@ -63,21 +97,31 @@ def transfer(host, local_file, remote_target):
         scp(host, bittornado_tgz, '%s/bittornado.tar.gz' % rp)
         ssh(host, "cd %s; tar zxvf bittornado.tar.gz > /dev/null" % rp)
         scp(host, murderclient_py, '%s/murder_client.py' % rp)
-    print 'python %s/murder_client.py peer %s %s' % (rp, remote_file, remote_target)
-    result = ssh(host, 'python %s/murder_client.py peer %s %s' % (rp,
-                    remote_file, remote_target))
+    command = 'python %s/murder_client.py peer %s %s' % (rp, remote_file, remote_target)
+    print "running \"%s\" on %s" %  (command, host)
+    result = ssh(host, command)
     ssh(host, 'rm %s' % remote_file)
     if result == 0:
         print "%s complete" % host
     else:
         print "%s FAILED with code %s" % (host, result)
+        while retry != 0:
+            retry = retry - 1
+            print "retrying on %s" % host
+            transfer(host, local_file, remote_target, 0)
 
 
 def ssh(host, command):
-    return subprocess.call(['ssh', '-o UserKnownHostsFile=/dev/null',
+    if not os.path.exists(opts['log_dir']):
+        os.makedirs(opts['log_dir'])
+        
+    with open("%s%s%s-ssh.log" % (opts['log_dir'], os.path.sep, host), 'a') as log:
+        result = subprocess.call(['ssh', '-o UserKnownHostsFile=/dev/null',
+                '-o LogLevel=quiet',
                 '-o StrictHostKeyChecking=no',
-                host, command], stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                host, command], stdout=log,
+                stderr=log)
+    return result
 
 
 def scp(host, local_file, remote_file):
@@ -95,7 +139,7 @@ def mktorrent(file_name, tracker):
 
 
 def track():
-    bttrack.track(["--dfile", DATA_FILE, "--port", PORT])
+    bttrack.track(["--dfile", opts['data_file'], "--port", opts['port']])
 
 
 def seed(torrent, local_file):
@@ -109,12 +153,10 @@ def local_ip():
     return s.getsockname()[0]
 
 
-if __name__ == '__main__':
-    if len(sys.argv) < 3:
-        sys.exit('ERROR: This command requires 3 command line options')
+def  herdmain():
+    if not os.path.exists(opts['hosts']):
+        sys.exit('ERROR: hosts file "%s" does not exist' % opts['hosts'])
+    hosts = [line.strip() for line in open(opts['hosts'], 'r') if not re.match("^#", line[0])]
+    run(opts['local-file'], opts['remote-file'], hosts)
 
-    if not os.path.exists(sys.argv[3]):
-        sys.exit('ERROR: hosts file "%s" does not exist' % sys.argv[3])
-
-    hosts = [line.strip() for line in open(sys.argv[3], 'r') if line[0] != '#']
-    run(sys.argv[1], sys.argv[2], hosts)
+herdmain()

--- a/murder_client.py
+++ b/murder_client.py
@@ -89,6 +89,7 @@ class HeadlessDisplayer:
         self.peerStatus = ''
         self.errors = []
         self.last_update_time = -1
+        self.return_code = 0
 
     def finished(self):
         global doneFlag
@@ -124,14 +125,16 @@ class HeadlessDisplayer:
         self.timeEst = 'Download Failed!'
         self.downRate = ''
         global doneFlag
+        self.return_code = 1
         doneFlag.set()
         #self.display()
 
     def error(self, errormsg):
-        #self.errors.append(errormsg)
+        self.errors.append(errormsg)
         self.display()
         global doneFlag
-        print errormsg
+        #print errormsg
+        self.return_code = 1
         doneFlag.set()
 
     def display(self, dpflag = Event(), fractionDone = None, timeEst = None,
@@ -257,6 +260,7 @@ def run(params):
         pass
     if not h.done:
         h.failed()
+    sys.exit(h.return_code)
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
We've been using this in prod for about a month or two now, and wanted to add these features based on our ops team's feedback.

Added argparse options instead of raw sys argv.

Fixed a regex bug where it wasn't accurately snagging comments.

Added in a retry option in case murder fails because of a time out or other problem.

Added in a log directory so you can see what failures are happening within the ssh session (not really applicable for scp, so I didn't put it in there).

Additionally, patched murder_client to return 1 in case of failure or error so that it can be handled upstream (It was returning success in all situations). This could theoretically be extended to provide more intelligent return codes, but just 0 or 1 :: "Success" or "Failure" should suffice for most cases. 

Finally, failures on particular nodes will be displayed on the screen instead of suppressed so you can take appropriate actions.
