### PR TITLE
Handling cases where herd.py is symlinked to another location

### DIFF
--- a/herd.py
+++ b/herd.py
@@ -67,7 +67,7 @@ ch.setFormatter(formatter)
 # add the handlers to the log
 log.addHandler(ch)
 
-herd_root = os.path.dirname(__file__)
+herd_root = os.path.dirname(os.path.realpath(__file__))
 bittornado_tgz = os.path.join(herd_root, 'bittornado.tar.gz')
 murderclient_py = os.path.join(herd_root, 'murder_client.py')
 


### PR DESCRIPTION
When making this a python package, it was trying to reference the symlinked location instead of the actual location of herd.py.

For example, if we put /usr/bin/herd as a symlink to /usr/lib/python<version>/site-packages/herd/herd.py, we want to reference the true location instead of the symlinked location.
