### PR TITLE
Allow --port range for random port selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ Create a file hosts.dat with a list of the hosts you want to copy to, and:
 
 * [Russ Garrett](http://github.com/russss)
 * [Laurie Denness](http://github.com/lozzd)
+* [Sam Gleske](http://github.com/samrocketman)


### PR DESCRIPTION
This way the tracker listens on a new random port each time herd.py is called.  This allows Herd to be integrated into a continuous delivery/continuous deployment environment.  This will allow the deployments to scale well in an automated deployment environment.

With port range socket is tested before port is used.

As a minor aside I alphabetically sorted the imports as well which is why there's so many changes in the imports.  Really I only added the following imports.

```
import random
import socket
```

SAM
